### PR TITLE
re-instate linux 64bit dist build

### DIFF
--- a/build/linux/dist.sh
+++ b/build/linux/dist.sh
@@ -73,14 +73,12 @@ find arduino -name "Thumbs.db" -exec rm -f {} ';'
 echo Creating tarball and finishing...
 version=maple-ide-$revision
 mv arduino $version
-# FIXME re-insert this once we've actually got a 64 bit version
-# echo Using 64-bit librxtxSerial.so
-# cp dist/lib/librxtxSerial.so.x86_64 $version/lib/librxtxSerial.so
-# cp dist/lib/RXTXcomm.jar.x86_64 $version/lib/RXTXcomm.jar
 
-# tar cfz $version-linux64.tgz $version
-
-# echo Done with 64bit.
+echo Using 64-bit librxtxSerial.so
+cp dist/lib/librxtxSerial.so.x86_64 $version/lib/librxtxSerial.so
+cp dist/lib/RXTXcomm.jar.x86_64 $version/lib/RXTXcomm.jar
+tar cfz $version-linux64.tgz $version
+echo Done with 64bit.
 
 echo Using 32-bit librxtxSerial.so
 cp dist/lib/librxtxSerial.so.i386 $version/lib/librxtxSerial.so


### PR DESCRIPTION
This reverts part of a commit mbolivar made a long time ago ("QA testing improvements; better snapshot file names.") which removed Linux 64bit IDE builds.

The in-line comment said "FIXME re-insert this once we've actually got a 64 bit version". I believe the x86_64 .jar files work fine on 64bit linux distros, while the default 32bit ones do not.
